### PR TITLE
Command キーが Windows / Linux で機能しない不具合修正

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -214,7 +214,7 @@ function createMenuItemForBoard() {
   menuItem.submenu.append(
     new MenuItem({
       label: "Preferences",
-      accelerator: "Command+,",
+      accelerator: "CommandOrControl+,",
       click() {
         ipcRenderer.send("window-open");
       }
@@ -323,7 +323,7 @@ function createBoardMenuItems() {
       boardMenuItems.push(
         new MenuItem({
           label: allOptions[i]["name"],
-          accelerator: `Command+Option+${i}`,
+          accelerator: `CommandOrControl+Option+${i}`,
           index: i,
           click() {
             moveClickedContentsToTop(clicked);
@@ -359,7 +359,7 @@ function createAdditionalPaneMenuItems(contents) {
   const additionalPaneMenuItems = contents.map(function(content) {
     return new MenuItem({
       label: content["name"],
-      accelerator: `Command+${content["index"] + 1}`,
+      accelerator: `CommandOrControl+${content["index"] + 1}`,
       click() {
         loadAdditionalPage(content["url"], content["customCSS"]);
       }
@@ -385,7 +385,7 @@ function createContextMenuItems(contents, index) {
 function createGoogleMenuItem() {
   return new MenuItem({
     label: "Search in Google",
-    accelerator: "Command+l",
+    accelerator: "CommandOrControl+l",
     click() {
       openGoogleInOverlay();
     }


### PR DESCRIPTION
## 概要
Command キーが Windows / Linux で機能しない不具合修正

## 詳細
- Windows / Linux では Command キーが機能しないため、Control で置き換えるように修正
    - リファレンス参照(https://electronjs.org/docs/api/accelerator#platform-notice)

## 検証
- 以下ショートカットキーが動作することを確認
    - [ ] Windows：Control + , / Control + Alt + {0} / Control + {0} / Control + l 
    - [ ] Mac：Command + , / Command + Option + {0} / Command + {0} / Command + l