### PR TITLE
拡大率を個別に設定できるようにする

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -136,7 +136,13 @@ function initialize() {
   const contents = json.contents;
   contents.forEach(function (content) {
     if (content["size"] === undefined) content["size"] = "small";
-    createPane(content["size"], content["url"], true);
+    if (content["zoom"] === undefined) content["zoom"] = 1.0;
+    createPane({
+      size: content["size"],
+      url: content["url"],
+      zoom: content["zoom"],
+      init: true
+    });
   });
 
   getWebviews().forEach(function (webview, index) {
@@ -624,7 +630,7 @@ function getPaneNum() {
 function loadAdditionalPage(additionalPage, customCSS = []) {
   resetWindowSize();
   const size = "small";
-  createPane(size, "");
+  createPane({ size });
   storeSize(getPaneNum() - 1, size);
   storeUrl(getPaneNum() - 1, additionalPage);
   storeCustomCSS(getPaneNum() - 1, customCSS);
@@ -667,14 +673,14 @@ function storeCustomCSS(index, customCSS) {
   store.set(`boards.0.contents.${index}.customCSS`, customCSS);
 }
 
-function createPane(size, url = "", init = false) {
+function createPane({ size, url = "", zoom = 1.0, init = false }) {
   let divContainer = createContainerDiv(size);
   let divButtons = createButtonDiv();
 
   document.getElementById("main-content").appendChild(divContainer);
   divContainer.appendChild(divButtons);
 
-  const webview = createWebview(url);
+  const webview = createWebview(url, { zoom });
   divContainer.appendChild(webview);
 
   createDraggableBar(size);
@@ -690,7 +696,7 @@ function createDraggableBar(size) {
   } else {
     div.id = `dvs-${getPaneNum() - 1}`;
     div.className = "dragbar-vertical-small";
-    div.style = `grid-column: ${(getPaneNum() - 1) * 2} / 
+    div.style = `grid-column: ${(getPaneNum() - 1) * 2} /
       ${(getPaneNum() - 1) * 2 + 1}`;
   }
   document.getElementById("main-content").appendChild(div);
@@ -711,11 +717,14 @@ function createButtonDiv() {
   return div;
 }
 
-function createWebview(url = "") {
+function createWebview(url = "", options = {}) {
   let webview = document.createElement("webview");
   webview.src = "about:blank";
   webview.id = "normal";
   webview.url = url;
+  webview.addEventListener("dom-ready", () => {
+    webview.setZoomFactor(Number(options.zoom) || 1.0);
+  });
   return webview;
 }
 

--- a/src/preference.js
+++ b/src/preference.js
@@ -260,6 +260,7 @@ function importNewBoard(source, boardName) {
         },
         {
           "name": "calendar",
+          "zoom": 1.0,
           "url": "https://okadash-files.s3-ap-northeast-1.amazonaws.com/calendar.html"
         }
       ]

--- a/src/preference.js
+++ b/src/preference.js
@@ -74,7 +74,7 @@ function showBoardContents(board, self) {
     zoomElem.innerHTML = "Zoom";
     zoomTextElem.type = "textbox";
     zoomTextElem.className = "content-textbox";
-    zoomTextElem.value = content["zoom"];
+    zoomTextElem.value = content["zoom"] || 1.0;
     zoomElem.appendChild(zoomTextElem);
 
     const cssElem = document.createElement("p");

--- a/src/preference.js
+++ b/src/preference.js
@@ -69,6 +69,14 @@ function showBoardContents(board, self) {
     if (/workspace/.test(content["url"])) urlTextElem.style.background = "#fdd";
     urlElem.appendChild(urlTextElem);
 
+    const zoomElem = document.createElement("p");
+    const zoomTextElem = document.createElement("input");
+    zoomElem.innerHTML = "Zoom";
+    zoomTextElem.type = "textbox";
+    zoomTextElem.className = "content-textbox";
+    zoomTextElem.value = content["zoom"];
+    zoomElem.appendChild(zoomTextElem);
+
     const cssElem = document.createElement("p");
     const tAreaElem = document.createElement("textarea");
     cssElem.innerHTML = "Custom CSS";
@@ -90,6 +98,7 @@ function showBoardContents(board, self) {
 
     divElem.appendChild(nameElem);
     divElem.appendChild(urlElem);
+    divElem.appendChild(zoomElem);
     divElem.appendChild(cssElem);
     divElem.appendChild(btnElem);
     divElem.appendChild(hrElem);
@@ -126,6 +135,13 @@ function createNewItem(self) {
   urlTextElem.className = "content-textbox";
   urlElem.appendChild(urlTextElem);
 
+  const zoomElem = document.createElement("p");
+  const zoomTextElem = document.createElement("input");
+  zoomElem.innerHTML = "Zoom";
+  zoomTextElem.type = "textbox";
+  zoomTextElem.className = "content-textbox";
+  zoomElem.appendChild(zoomTextElem);
+
   const cssElem = document.createElement("p");
   const tAreaElem = document.createElement("textarea");
   cssElem.innerHTML = "Custom CSS";
@@ -144,6 +160,7 @@ function createNewItem(self) {
 
   divElem.appendChild(nameElem);
   divElem.appendChild(urlElem);
+  divElem.appendChild(zoomElem);
   divElem.appendChild(cssElem);
   divElem.appendChild(btnElem);
   divElem.appendChild(hrElem);
@@ -209,6 +226,7 @@ function importNewBoard(source, boardName) {
           "name": "Slack",
           "url": "https://${workspaceName}.slack.com",
           "size": "large",
+          "zoom": 1.0,
           "customCSS": [
             ".p-channel_sidebar { width: 160px !important; }",
             ".p-classic_nav__team_header { display: none !important; }",
@@ -219,11 +237,13 @@ function importNewBoard(source, boardName) {
           "name": "Google News",
           "url": "https://news.google.com/",
           "size": "medium",
+          "zoom": 1.0,
           "customCSS": []
         },
         {
           "name": "Slack(body)",
           "url": "https://${workspaceName}.slack.com",
+          "zoom": 1.0,
           "customCSS": [
             ".p-workspace__sidebar { display: none !important; }",
             ".p-classic_nav__team_header { display: none !important;}",
@@ -235,6 +255,7 @@ function importNewBoard(source, boardName) {
         {
           "name": "twitter",
           "url": "https://twitter.com",
+          "zoom": 1.0,
           "customCSS": ["header { display: none !important; }"]
         },
         {
@@ -409,6 +430,12 @@ function saveBoardSetting() {
           if (!isValidURL(elem.querySelector("input").value, elem.querySelector("input")))
             error = true;
           break;
+        case "Zoom":
+          item.zoom = elem.querySelector("input").value;
+          if (!isValidZoom(item.zoom, elem.querySelector("input"))) {
+            error = true;
+          }
+          break;
         case "Custom CSS":
           item.customCSS = elem.querySelector("textarea").value.split("\n");
           items.push(item);
@@ -475,5 +502,20 @@ function isValidURL(url, elem) {
     return false;
   }
   elem.style.background = "#fff";
+  return true;
+}
+
+function isValidZoom(zoom, elem) {
+  if (zoom == "") {
+    alert("Zoom is Needed");
+    elem.style.background = "#fdd";
+    return false;
+  }
+  zoomNum = Number(zoom);
+  if (isNaN(zoomNum) || zoomNum < 0.25 || zoomNum > 5.0) {
+    alert("Zoom must be a number between 0.25 and 5.0");
+    elem.style.background = "#fdd";
+    return false;
+  }
   return true;
 }


### PR DESCRIPTION
# WHAT

ボード内の各種アイテムの拡大率(webview.getZoomFactor)を設定できるようにします。

<img width="945" alt="スクリーンショット 2020-04-20 16 49 19" src="https://user-images.githubusercontent.com/36019803/79727179-ef006d80-8326-11ea-93c0-571cf7be4634.png">


# WHY

ボード内に情報を詰め込むために、一部のアイテムは小さく表示したりするなど、よりカスタム性を高めるため

# HOW

- preference画面から、アイテムごとの`Zoom`を設定できるようにする
- 各Webviewの初期化時に、`Zoom`の値に基づく拡大率を設定する

# 検証

以下内容を手動で確認済み

1. Storeをリセットしてokadashを起動: 正常にデフォルトのボードが描画される
2. Preferenceを開くと、デフォルトボードの全てのアイテムにZoom = 1の設定がされている
3. Save,Closeすると、デフォルトボードが正しく描画される
4. デフォルトボードの内容をJSON出力して内容を確認するとzoomが1になっている
5. このJSONファイルの内容を改変し、zoomを0.25から5の間の数字にし、インポートすると正常に読み込まれる
6. Preference内でzoomの値を0.25から5の範囲で書き換えて、Save,Closeするとボードに正しく反映される
7. Preference内で、zoomの値を空欄、文字列、0.25未満、5.0より大きい値にした場合、Saveするとエラーが表示される
8. zoomの値が指定されていない古いJSONファイルをインポートすると、デフォルト値1.0が設定された状態で読み込まれる