### PR TITLE
Webviewクラスを導入し、Webview周りの責務を分離

### DIFF
--- a/src/components/webview.js
+++ b/src/components/webview.js
@@ -1,0 +1,100 @@
+/**
+ * webview要素のラッパークラス
+ * Web画面の設定、管理、操作を行う
+ * このクラスはWebview要素自身以外(e.g.親要素)には一切関心を持たない
+ */
+class WebView {
+  /**
+   * オブジェクト生成時に完成したWebViewを生成する
+   * @param {Object}   params
+   * @param {string}   params.url
+   * @param {number}   params.zoom
+   * @param {[string]} params.customCSS
+   */
+  constructor({ url, zoom, customCSS }) {
+    this.url = url || "";
+    this.zoom = zoom || 1.0;
+    this.customCSS = customCSS || [];
+    this.element = createWebViewElement(url);
+    this.shortcutKeyMap = {
+      "meta+[": element => element.goBack(),
+      "meta+]": element => element.goForward()
+    };
+
+    this.initialize();
+  }
+
+  /**
+   * Webview要素の初期設定を行う
+   */
+  initialize() {
+    if (isValidURL(this.url)) this.element.src = this.url;
+    this.element.autosize = "on";
+    this.element.addEventListener("dom-ready", () => {
+      this.apply();
+      this.element
+        .getWebContents()
+        .on("before-input-event", (_, e) => this.execShortcutKey(e));
+    });
+  }
+
+  /**
+   * プロパティの内容に応じてWebView要素の設定を更新する
+   */
+  apply() {
+    this.element.insertCSS(this.customCSS.join(" "));
+    this.element.setZoomFactor(Number(this.zoom) || 1.0);
+    this.element.focus();
+  }
+
+  /**
+   * ショートカットキーを実行する
+   * @param {any} event キーボードイベント
+   */
+  execShortcutKey(event) {
+    const keyLabel = `${event.meta ? "meta+" : ""}${event.key}`;
+    const f = this.shortcutKeyMap[keyLabel];
+    if (f) f(this.element);
+  }
+
+  /**
+   * ショートカットキーを追加する
+   * @param {string} label ショートカットキーを表す文字列(e.g."meta+w")
+   * @param {function(Electron.WebviewTag)} callback
+   */
+  addShortcutKey(label, callback) {
+    this.shortcutKeyMap[label] = callback;
+  }
+}
+
+module.exports = WebView;
+
+/**
+ * Webview要素を生成する
+ * @param {string} url
+ */
+function createWebViewElement(url) {
+  const element = document.createElement("webview");
+  element.src = "about:blank";
+  element.id = "normal";
+  element.url = url;
+  element.addEventListener("new-window", event => openExternal(event.url));
+  return element;
+}
+
+/**
+ * アプリケーションの外側でURLを開く
+ * @param {string} url
+ */
+function openExternal(url) {
+  if (isValidURL(url)) shell.openExternal(url);
+}
+
+/**
+ * 正当なURLであるかを評価する
+ * @param {string} url
+ */
+function isValidURL(url) {
+  const protocol = require("url").parse(url).protocol;
+  return protocol === "http:" || protocol === "https:" || protocol === "file:";
+}

--- a/src/main.js
+++ b/src/main.js
@@ -188,9 +188,9 @@ function initialize() {
   // 描画されたWebviewにショートカットキーと操作ボタンを追加する
   getWebviews().forEach(function (webview) {
     webview.addEventListener("dom-ready", function () {
-      const isSmallPain = webview.parentNode.classList.contains("small");
+      const isSmallPane = webview.parentNode.classList.contains("small");
       const hasButtons = webview.previousSibling.hasChildNodes();
-      if (isSmallPain && !hasButtons) {
+      if (isSmallPane && !hasButtons) {
         addButtons(webview.previousSibling, webview.parentNode.id);
       }
       addMaximizeButton(webview.parentNode, webview.parentNode.id);
@@ -564,7 +564,7 @@ function removeOverlay() {
  * smallペインを削除する
  * @param {number} index 対象ペインのインデックス
  */
-function removeSmallPain(index) {
+function removeSmallPane(index) {
   draggingBoarder.id = "";
   const target = document.getElementById(index);
   const targetBar = document.getElementById(`dvs-${index}`);
@@ -672,7 +672,7 @@ function addButtons(div, index) {
   if (index != 2)
     div.innerHTML += `<button onclick=move(${index},"-1") style="font-size: 12px";><</button>`;
   if (getPaneNum() !== 3)
-    div.innerHTML += `<button onclick=removeSmallPain(${index}) style="font-size: 12px";>Close</button>`;
+    div.innerHTML += `<button onclick=removeSmallPane(${index}) style="font-size: 12px";>Close</button>`;
   if (index != getPaneNum() - 1)
     div.innerHTML += `<button onclick=move(${index},"1") style="font-size: 12px";>></button>`;
 }
@@ -809,8 +809,8 @@ function createPane({ size, url, zoom, customCSS }, init = false) {
   document.getElementById("main-content").appendChild(divContainer);
   divContainer.appendChild(divButtons);
 
-  const forSmallPain = size === "small";
-  const webview = createWebView({ url, zoom, customCSS, forSmallPain });
+  const forSmallPane = size === "small";
+  const webview = createWebView({ url, zoom, customCSS, forSmallPane });
   divContainer.appendChild(webview.element);
 
   createDraggableBar(size);
@@ -916,15 +916,15 @@ function loadSettings() {
  * @param {number}   params.zoom
  * @param {[string]} params.customCSS
  * @param {boolean}  params.forOverlay   オーバレイ用途であるか
- * @param {boolean}  params.forSmallPain smallペイン用途であるか
+ * @param {boolean}  params.forSmallPane smallペイン用途であるか
  */
-function createWebView({ url, zoom, customCSS, forOverlay, forSmallPain }) {
+function createWebView({ url, zoom, customCSS, forOverlay, forSmallPane }) {
   const webview = new WebView({ url, zoom, customCSS });
   if (forOverlay) {
     webview.addShortcutKey("Escape", _ => removeOverlay());
     webview.addShortcutKey("meta+w", _ => removeOverlay());
-  } else if (forSmallPain) {
-    webview.addShortcutKey("meta+w", webview => removeSmallPain(webview.parentNode.id));
+  } else if (forSmallPane) {
+    webview.addShortcutKey("meta+w", webview => removeSmallPane(webview.parentNode.id));
   }
   return webview;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -506,7 +506,7 @@ function getAdditionalPaneInfo(contents) {
     }
     return {
       name: content["name"],
-      url: url.href,
+      url: content["url"],
       customCSS: content["customCSS"],
       index: index
     };


### PR DESCRIPTION
# WHAT

webviewクラスを作成し、webview周りの責務を委譲します

# WHY

main.jsで全てのロジックが書かれてると依存関係が見えづらく機能改修が大変なので

# HOW

- webviewタグの生成、操作に関してはwebviewクラスに任せる
- 親要素とか、webviewの外の世界については関心持たない