### PR TITLE
設定ファイルのインポート時に、ファイル名をボードのデフォルト名にする

### DIFF
--- a/src/preference.js
+++ b/src/preference.js
@@ -216,8 +216,10 @@ function openFileAndSave() {
  */
 function showModalDialogElement(filePath) {
   return new Promise((resolve, reject) => {
+    const filename = path.basename(filePath, ".json");
     const dlg = document.querySelector("#input-dialog");
     dlg.style.display = "block";
+    dlg.querySelector("input").value = filename;
     dlg.addEventListener("cancel", event => {
       event.preventDefault();
     });


### PR DESCRIPTION
# WHAT

preferenceから、設定ファイルをインポートする際に、ファイル名を元にボードのデフォルト名を決定します。

# WHY

大体の場合はファイル名をそのままボード名にするので良さそうなので