### PR TITLE
Slack のボディ部分のみ表示するカスタムCSSを初期設定に反映

### DIFF
--- a/src/preference.js
+++ b/src/preference.js
@@ -279,7 +279,6 @@ function importNewBoard(source, boardName) {
             ".p-workspace__sidebar { display: none !important; }",
             ".p-classic_nav__team_header { display: none !important;}",
             ".p-workspace--context-pane-collapsed { grid-template-columns: 0px auto !important;}",
-            ".p-workspace--classic-nav { grid-template-rows: min-content 60px auto !important;}",
             ".p-workspace--context-pane-expanded { grid-template-columns: 0px auto !important;}"
           ]
         },


### PR DESCRIPTION
## 前提
Slack のレイアウト刷新にともない、ボディ部分のみを表示するカスタムCSSが意図通りに動いていなかった。

## 概要
`.p-workspace--classic-nav` 要素がなくなったのでカスタムCSSからも削除します。
意図通りにボディ部分のみが抜き出されたペインができることを確認済みです。