### PR TITLE
largeペインを折りたたむ機能を廃止

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -15,7 +15,6 @@
     />
   </head>
   <body>
-    <label class="fold-large" onclick="moveClickedContentsToTop(1);">◀</label>
     <div id="main-content"></div>
 
     <dialog id="input-dialog">

--- a/src/style.css
+++ b/src/style.css
@@ -170,15 +170,6 @@ dialog {
   position: absolute;
   cursor: row-resize;
 }
-.fold-large {
-  position: absolute;
-  top: 0%;
-  right: -4px;
-  height: 100%;
-  background: none;
-  z-index: 1;
-  color: black;
-}
 #alert-icon {
   display: none;
   position: absolute;


### PR DESCRIPTION
# WHAT

largeペインを折りたたむ機能(と思われるUI)を削除

# WHY

該当機能はhttps://github.com/konoyono/okadash/commit/9e16413b37e566e1c6b766e76e73eec9b4aca427 あたりで使えなくなっているが、UIが残っていて、操作次第ではクラッシュすることがわかったので