### PR TITLE
アプリケーション終了時にウィンドウの位置とサイズを保持し、次回起動時に読み込む

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ let isSubOpen = false;
 let isInitOpen = false;
 
 // loading window size and position
-const boundsFile = path.join(app.getPath('userData'), 'bounds.json');
+const boundsFilePath = path.join(app.getPath('userData'), 'bounds.json');
 let bounds = {};
 try {
   bounds = JSON.parse(fs.readFileSync(boundsFile, 'utf8'));

--- a/src/index.js
+++ b/src/index.js
@@ -4,11 +4,22 @@ const electron = require("electron");
 const app = electron.app;
 const ipcMain = electron.ipcMain;
 const BrowserWindow = electron.BrowserWindow;
+const path = require('path');
+const fs = require("fs");
 let mainWindow;
 let subWindow;
 let initWindow;
 let isSubOpen = false;
 let isInitOpen = false;
+
+// loading window size and position
+const boundsFile = path.join(app.getPath('userData'), 'bounds.json');
+let bounds = {};
+try {
+  bounds = JSON.parse(fs.readFileSync(boundsFile, 'utf8'));
+} catch (e) {
+  bounds = { "width": 1024, "height": 768 };
+}
 
 // for Google Analytics
 const ua = require("universal-analytics");
@@ -42,13 +53,17 @@ app.on("ready", function () {
     }
   });
   trackEvent("main", "Open App");
-  mainWindow.maximize();
+  mainWindow.setBounds(bounds);
   mainWindow.loadURL("file://" + __dirname + "/index.html");
 
   mainWindow.on("closed", function () {
     mainWindow = null;
   });
 });
+
+app.on("quit", function () {
+  fs.writeFileSync(boundsFile, JSON.stringify(mainWindow.getBounds()));
+})
 
 ipcMain.on("window-open", function () {
   if (isSubOpen) return;


### PR DESCRIPTION
#29 対応。

https://qiita.com/Linda_pp/items/a81e1fd34951ae7d2dc4
https://www.electronjs.org/docs/api/browser-window#winsetboundsbounds-animate

上記URLあたりを参考に。
`config.json` と同じディレクトリに `bounds.json` を作成し、起動時にロードします。

`bounds.json` には `{"x":200,"y":20,"width":1400,"height":900}` のように、
ウィンドウの位置とサイズが記録されます。

