### PR TITLE
ボードが一つも存在しないときに、初期設定画面を呼び出す

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -978,17 +978,17 @@ function saveNewContents() {
 
 /**
  * Storeから取得したボードオブジェクトを元に描画用のボードオブジェクトを生成する
- * @param {Object} borad ボードオブジェクト
+ * @param {Object} board ボードオブジェクト
  */
-function buildJsonObjectFromStoredData(borad) {
+function buildJsonObjectFromStoredData(board) {
   let newContents = [];
-  if (borad === undefined) ipcRenderer.send("window-open");
-  borad["contents"].forEach(function (content) {
+  if (board === undefined) ipcRenderer.send("initial-open");
+  board["contents"].forEach(function (content) {
     if (content !== null) newContents.push(content);
   });
   store.set("boards.0.contents", newContents);
   let jsonObj = {
-    name: borad["name"],
+    name: board["name"],
     contents: newContents
   };
 


### PR DESCRIPTION
#35 対応。

デフォルトのボードを誤って削除してしまい、ボードが一つも存在しないときには
preference 画面ではなく、以下の初期設定画面を呼び出す。あわせて周辺の typo も修正。

--- 

![image](https://user-images.githubusercontent.com/8579173/80405860-2a3e0600-88fe-11ea-9645-5aa4a89948dc.png)

