### PR TITLE
Webview内で右クリックメニューを使えるように

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,11 @@
         "defer-to-connect": "^1.0.1"
       }
     },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+    },
     "@types/debug": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
@@ -213,6 +218,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="
     },
     "async-exit-hook": {
       "version": "2.0.1",
@@ -487,6 +497,50 @@
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.0.tgz",
       "integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w==",
       "dev": true
+    },
+    "cli-truncate": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+      "requires": {
+        "slice-ansi": "^3.0.0",
+        "string-width": "^4.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
+      }
     },
     "cliui": {
       "version": "5.0.0",
@@ -887,6 +941,26 @@
         }
       }
     },
+    "electron-context-menu": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/electron-context-menu/-/electron-context-menu-2.0.0.tgz",
+      "integrity": "sha512-z6OQlUDgcu6wQ34JHEF1Y6QNXkEzOuEXdM4Tew853/4DsaCthKBbAo2BH+4y+49f89WjG9WOUTwGhEO4tY5mUw==",
+      "requires": {
+        "cli-truncate": "^2.0.0",
+        "electron-dl": "^3.0.0",
+        "electron-is-dev": "^1.0.1"
+      }
+    },
+    "electron-dl": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/electron-dl/-/electron-dl-3.0.0.tgz",
+      "integrity": "sha512-TeBRv+vQgNVLGf/XLV4EYfYIBMI4TQcw84aDlM8xEm/1Lgxux3PUXDzaingivf+6jMvRojXSRPTHmiWI/6LrqQ==",
+      "requires": {
+        "ext-name": "^5.0.0",
+        "pupa": "^2.0.1",
+        "unused-filename": "^2.1.0"
+      }
+    },
     "electron-download": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/electron-download/-/electron-download-4.1.1.tgz",
@@ -903,6 +977,11 @@
         "semver": "^5.4.1",
         "sumchecker": "^2.0.2"
       }
+    },
+    "electron-is-dev": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-1.2.0.tgz",
+      "integrity": "sha512-R1oD5gMBPS7PVU8gJwH6CtT0e6VSoD0+SzSnYpNm+dBkcijgA+K7VAMHDfnRq/lkKPZArpzplTW6jfiMYosdzw=="
     },
     "electron-publish": {
       "version": "21.2.0",
@@ -987,6 +1066,11 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "escape-goat": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-2.1.1.tgz",
+      "integrity": "sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q=="
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -1017,6 +1101,23 @@
         "p-finally": "^1.0.0",
         "signal-exit": "^3.0.0",
         "strip-eof": "^1.0.0"
+      }
+    },
+    "ext-list": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
+      "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
+      "requires": {
+        "mime-db": "^1.28.0"
+      }
+    },
+    "ext-name": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
+      "integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
+      "requires": {
+        "ext-list": "^2.0.0",
+        "sort-keys-length": "^1.0.0"
       }
     },
     "extend": {
@@ -1348,6 +1449,11 @@
         "path-is-inside": "^1.0.1"
       }
     },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -1635,6 +1741,11 @@
       "requires": {
         "minimist": "^1.2.5"
       }
+    },
+    "modify-filename": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/modify-filename/-/modify-filename-1.1.0.tgz",
+      "integrity": "sha1-mi3sg4Bvuy2XXyK+7IWcoms5OqE="
     },
     "ms": {
       "version": "2.1.2",
@@ -1942,6 +2053,14 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
+    "pupa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pupa/-/pupa-2.0.1.tgz",
+      "integrity": "sha512-hEJH0s8PXLY/cdXh66tNEQGndDrIKNqNC5xmrysZy3i5C3oEoLna7YAOad+7u125+zH1HNXUmGEkrhb3c2VriA==",
+      "requires": {
+        "escape-goat": "^2.0.0"
+      }
+    },
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
@@ -2187,6 +2306,61 @@
       "dev": true,
       "requires": {
         "string-width": "^1.0.1"
+      }
+    },
+    "slice-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        }
+      }
+    },
+    "sort-keys": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+      "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+      "requires": {
+        "is-plain-obj": "^1.0.0"
+      }
+    },
+    "sort-keys-length": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sort-keys-length/-/sort-keys-length-1.0.1.tgz",
+      "integrity": "sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=",
+      "requires": {
+        "sort-keys": "^1.0.0"
       }
     },
     "source-map": {
@@ -2504,6 +2678,22 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
+    },
+    "unused-filename": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unused-filename/-/unused-filename-2.1.0.tgz",
+      "integrity": "sha512-BMiNwJbuWmqCpAM1FqxCTD7lXF97AvfQC8Kr/DIeA6VtvhJaMDupZ82+inbjl5yVP44PcxOuCSxye1QMS0wZyg==",
+      "requires": {
+        "modify-filename": "^1.1.0",
+        "path-exists": "^4.0.0"
+      },
+      "dependencies": {
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+        }
+      }
     },
     "update-notifier": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "prettier": "^2.0.4"
   },
   "dependencies": {
+    "electron-context-menu": "^2.0.0",
     "electron-search-text": "^0.3.0",
     "electron-store": "^4.0.0",
     "jquery": "^3.4.1",

--- a/src/components/webview.js
+++ b/src/components/webview.js
@@ -104,6 +104,19 @@ class WebView {
       window: this.element,
       prepend: (_, params) => [
         {
+          label: "Go Back",
+          visible: this.element.canGoBack(),
+          click: () => this.element.goBack()
+        },
+        {
+          label: "Go Forward",
+          visible: this.element.canGoForward(),
+          click: () => this.element.goForward()
+        },
+        {
+          type: "separator"
+        },
+        {
           label: "Open in external browser",
           visible: isValidURL(params.linkURL),
           click: () => {

--- a/src/components/webview.js
+++ b/src/components/webview.js
@@ -24,6 +24,7 @@ class WebView {
       "meta+]": element => element.goForward()
     };
     this.seacher = null;
+    this.disposeContextMenu = null;
 
     this.initialize();
   }
@@ -36,11 +37,11 @@ class WebView {
     this.element.autosize = "on";
     this.element.addEventListener("dom-ready", () => {
       this.apply();
+      this.initializeContextMenu();
       this.element
         .getWebContents()
         .on("before-input-event", (_, e) => this.execShortcutKey(e));
     });
-    this.initializeContextMenu();
   }
 
   /**
@@ -99,7 +100,7 @@ class WebView {
    * Webviewに右クリックメニューを埋め込む
    */
   initializeContextMenu() {
-    ContextMenu({
+    this.disposeContextMenu = ContextMenu({
       window: this.element,
       prepend: (_, params) => [
         {
@@ -111,6 +112,17 @@ class WebView {
         }
       ]
     });
+  }
+
+  /**
+   * WebViewを安全に破棄する
+   * 生成したWebviewElementを破棄する際は必ずこのメソッドを通すこと
+   */
+  dispose() {
+    if (this.disposeContextMenu) {
+      this.disposeContextMenu();
+    }
+    this.element.remove();
   }
 }
 

--- a/src/components/webview.js
+++ b/src/components/webview.js
@@ -1,3 +1,4 @@
+const ContextMenu = require("electron-context-menu");
 const ElectronSearchText = require("electron-search-text");
 
 /**
@@ -39,6 +40,7 @@ class WebView {
         .getWebContents()
         .on("before-input-event", (_, e) => this.execShortcutKey(e));
     });
+    this.initializeContextMenu();
   }
 
   /**
@@ -90,6 +92,21 @@ class WebView {
     this.addShortcutKey("meta+f", () => {
       this.seacher.emit("show");
       this.seacher.findInPage();
+    });
+  }
+
+  initializeContextMenu() {
+    ContextMenu({
+      window: this.element,
+      prepend: (_, params) => [
+        {
+          label: "Open in external browser",
+          visible: isValidURL(params.linkURL),
+          click: () => {
+            openExternal(params.linkURL);
+          }
+        }
+      ]
     });
   }
 }

--- a/src/components/webview.js
+++ b/src/components/webview.js
@@ -95,6 +95,9 @@ class WebView {
     });
   }
 
+  /**
+   * Webviewに右クリックメニューを埋め込む
+   */
   initializeContextMenu() {
     ContextMenu({
       window: this.element,

--- a/src/main.js
+++ b/src/main.js
@@ -813,7 +813,8 @@ function loadAdditionalPage({ name, url, zoom = 1.0, customCSS = [] }) {
  */
 function recreateSelectedPane(index, {name, url, zoom, customCSS }) {
   const div = document.getElementById(`${index}`);
-  div.querySelector("webview").remove();
+  const webViewElm = div.querySelector("webview");
+  convertToWebViewInstance(webViewElm).dispose();
 
   storeName(index, name);
   storeUrl(index, url);


### PR DESCRIPTION
# WHAT

Webview内で右クリックメニューを出来るようにします。

- 全ての要素で: 要素の検証、戻る(戻れる時)、進む(進める時)
- テキスト選択で: コピー、リンクをコピー、テキストをグーグル検索
- リンク選択で: 外部ブラウザで開く
- テキストボックスで: カット、ペースト

![スクリーンショット 2020-04-30 19 38 47](https://user-images.githubusercontent.com/36019803/80701545-7feefa00-8b1a-11ea-9c04-a1f5850069cd.png)

Webview内を右クリックで、基本的な右クリックメニューを使えるようにします。
![スクリーンショット 2020-04-30 19 39 26](https://user-images.githubusercontent.com/36019803/80701549-81b8bd80-8b1a-11ea-9a9e-2e1746b3416b.png)

# WHY

当たり前機能だと思ったので

# HOW

Electronのwebviewはデフォルトでそういう仕組みを持ってないので、それらしいパッケージを導入
https://github.com/sindresorhus/electron-context-menu

だいたいはデフォルト設定で満足できるけど、外部ブラウザで開きたい場合が強いと思ったので、そこだけカスタム定義