### PR TITLE
スモールペイン下部のボタンの存在感を薄くする

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -48,6 +48,10 @@ dialog .name,.url {
   line-height: 0;
   overflow: visible;
   cursor: pointer;
+  opacity: 0.1;
+}
+.reload-button:hover {
+  opacity: 1;
 }
 .max-button {
   display: inline-block;
@@ -63,6 +67,10 @@ dialog .name,.url {
   line-height: 0;
   overflow: visible;
   cursor: pointer;
+  opacity: 0.1;
+}
+.max-button:hover {
+  opacity: 1;
 }
 
 .search-box {

--- a/src/style.css
+++ b/src/style.css
@@ -99,6 +99,10 @@ dialog .name,.url {
   position: absolute;
   bottom: 30px;
   z-index: 1;
+  opacity: 0.1;
+}
+.tool-buttons:hover {
+  opacity: 1;
 }
 .large {
   grid-row: 1 / 100; /* large enough */


### PR DESCRIPTION
![0503](https://user-images.githubusercontent.com/8579173/80915833-b2555d00-8d8f-11ea-88c0-7843de0c5897.gif)

スモールペイン下部のボタンが邪魔なので普段はほぼ非表示（`opacity: 0.1;`）にしておき、
gif のようにマウスホバー時に表示するようにします。時計とかぶってうざいんだ。