### PR TITLE
feat: Cmd + L でアドレスダイアログを開く機能

### DIFF
--- a/src/components/webview.js
+++ b/src/components/webview.js
@@ -38,6 +38,7 @@ class WebView {
     this.element.addEventListener("dom-ready", () => {
       this.apply();
       this.initializeContextMenu();
+      this.initializeUrlDialogShortcut();
       this.element
         .getWebContents()
         .on("before-input-event", (_, e) => this.execShortcutKey(e));
@@ -94,6 +95,18 @@ class WebView {
       this.seacher.emit("show");
       this.seacher.findInPage();
     });
+  }
+
+  /**
+   * meta + U でアドレスダイアログを開く
+   */
+  initializeUrlDialogShortcut(){
+    this.addShortcutKey("meta+u", () => {
+      const localElement = remote.webContents.fromId(this.element.getWebContentsId());
+      const url = localElement.getURL();      
+      const ev = new CustomEvent("openReplaceUrlDialog", {detail: {url, id: this.element.id}})
+      window.dispatchEvent(ev)
+    })
   }
 
   /**

--- a/src/components/webview.js
+++ b/src/components/webview.js
@@ -38,7 +38,6 @@ class WebView {
     this.element.addEventListener("dom-ready", () => {
       this.apply();
       this.initializeContextMenu();
-      this.initializeUrlDialogShortcut();
       this.element
         .getWebContents()
         .on("before-input-event", (_, e) => this.execShortcutKey(e));
@@ -94,20 +93,6 @@ class WebView {
     this.addShortcutKey("meta+f", () => {
       this.seacher.emit("show");
       this.seacher.findInPage();
-    });
-  }
-
-  /**
-   * meta + L でURLダイアログを開くショートカットを埋め込む
-   */
-  initializeUrlDialogShortcut() {
-    this.addShortcutKey("meta+l", () => {
-      const localElement = remote.webContents.fromId(this.element.getWebContentsId());
-      const url = localElement.getURL();
-      const ev = new CustomEvent("openReplaceUrlDialog", {
-        detail: { url, id: this.element.id }
-      });
-      window.dispatchEvent(ev);
     });
   }
 

--- a/src/components/webview.js
+++ b/src/components/webview.js
@@ -98,7 +98,7 @@ class WebView {
   }
 
   /**
-   * meta + U でURLダイアログを開く
+   * meta + U でURLダイアログを開くショートカットを埋め込む
    */
   initializeUrlDialogShortcut() {
     this.addShortcutKey("meta+u", () => {

--- a/src/components/webview.js
+++ b/src/components/webview.js
@@ -98,7 +98,7 @@ class WebView {
   }
 
   /**
-   * meta + U でアドレスダイアログを開く
+   * meta + U でURLダイアログを開く
    */
   initializeUrlDialogShortcut(){
     this.addShortcutKey("meta+u", () => {

--- a/src/components/webview.js
+++ b/src/components/webview.js
@@ -98,10 +98,10 @@ class WebView {
   }
 
   /**
-   * meta + U でURLダイアログを開くショートカットを埋め込む
+   * meta + L でURLダイアログを開くショートカットを埋め込む
    */
   initializeUrlDialogShortcut() {
-    this.addShortcutKey("meta+u", () => {
+    this.addShortcutKey("meta+l", () => {
       const localElement = remote.webContents.fromId(this.element.getWebContentsId());
       const url = localElement.getURL();
       const ev = new CustomEvent("openReplaceUrlDialog", {

--- a/src/components/webview.js
+++ b/src/components/webview.js
@@ -100,13 +100,15 @@ class WebView {
   /**
    * meta + U でURLダイアログを開く
    */
-  initializeUrlDialogShortcut(){
+  initializeUrlDialogShortcut() {
     this.addShortcutKey("meta+u", () => {
       const localElement = remote.webContents.fromId(this.element.getWebContentsId());
-      const url = localElement.getURL();      
-      const ev = new CustomEvent("openReplaceUrlDialog", {detail: {url, id: this.element.id}})
-      window.dispatchEvent(ev)
-    })
+      const url = localElement.getURL();
+      const ev = new CustomEvent("openReplaceUrlDialog", {
+        detail: { url, id: this.element.id }
+      });
+      window.dispatchEvent(ev);
+    });
   }
 
   /**

--- a/src/main.js
+++ b/src/main.js
@@ -508,6 +508,21 @@ function openNewPaneFromUrlDialog(index = null) {
   dlg.addEventListener("close", onClose, { once: true });
 }
 
+function replacePaneFromUrlDialog(event){
+  const {url, id} = event.detail
+  const dlg = document.querySelector("#create-new-pane-dialog");
+
+  const index = getWebviews().findIndex(webView => {
+    return webView.id === id
+  })
+  const pane = store.get("boards")[currentBoardIndex].contents[index]
+  dlg.querySelector(".url").value = url; 
+  dlg.querySelector(".name").value = pane.name;
+
+  openNewPaneFromUrlDialog(index)
+}
+window.addEventListener("openReplaceUrlDialog", replacePaneFromUrlDialog)
+
 /**
  * ボード内アイテムリストを元に、メニュー用のオブジェクトリストを戻す
  * @param {Array} contents ボード内のアイテムリスト

--- a/src/main.js
+++ b/src/main.js
@@ -508,6 +508,11 @@ function openNewPaneFromUrlDialog(index = null) {
   dlg.addEventListener("close", onClose, { once: true });
 }
 
+/**
+ * eventから現在のペインのURLとidを受け取り、
+ * ペインを変更するためのダイアログを開く
+ * @param {*} event 
+ */
 function replacePaneFromUrlDialog(event){
   const {url, id} = event.detail
   const dlg = document.querySelector("#create-new-pane-dialog");

--- a/src/main.js
+++ b/src/main.js
@@ -990,7 +990,7 @@ function loadSettings() {
  */
 function createWebView(id, { url, zoom, customCSS, forOverlay, forSmallPane }) {
   const webview = new WebView({ url, zoom, customCSS });
-  webview.addShortcutKey("meta+l", webview => openUrlChangeDialog(webview));
+  webview.addShortcutKey("meta+l", openUrlChangeDialog);
   if (forOverlay) {
     webview.addShortcutKey("Escape", _ => removeOverlay());
     webview.addShortcutKey("meta+w", _ => removeOverlay());

--- a/src/main.js
+++ b/src/main.js
@@ -511,22 +511,22 @@ function openNewPaneFromUrlDialog(index = null) {
 /**
  * eventから現在のペインのURLとidを受け取り、
  * ペインを変更するためのダイアログを開く
- * @param {*} event 
+ * @param {*} event
  */
-function replacePaneFromUrlDialog(event){
-  const {url, id} = event.detail
+function replacePaneFromUrlDialog(event) {
+  const { url, id } = event.detail;
   const dlg = document.querySelector("#create-new-pane-dialog");
 
   const index = getWebviews().findIndex(webView => {
-    return webView.id === id
-  })
-  const pane = store.get("boards")[currentBoardIndex].contents[index]
-  dlg.querySelector(".url").value = url; 
+    return webView.id === id;
+  });
+  const pane = store.get("boards")[currentBoardIndex].contents[index];
+  dlg.querySelector(".url").value = url;
   dlg.querySelector(".name").value = pane.name;
 
-  openNewPaneFromUrlDialog(index)
+  openNewPaneFromUrlDialog(index);
 }
-window.addEventListener("openReplaceUrlDialog", replacePaneFromUrlDialog)
+window.addEventListener("openReplaceUrlDialog", replacePaneFromUrlDialog);
 
 /**
  * ボード内アイテムリストを元に、メニュー用のオブジェクトリストを戻す

--- a/src/main.js
+++ b/src/main.js
@@ -768,6 +768,18 @@ function addMaximizeButton(div, index) {
 }
 
 /**
+ * URL変更ダイアログを開く
+ * @param {Element} webview
+ */
+function openUrlChangeDialog(webview) {
+  const url = webview.getURL();
+  const ev = new CustomEvent("openReplaceUrlDialog", {
+    detail: { url, id: webview.id }
+  });
+  window.dispatchEvent(ev);
+}
+
+/**
  * ペインリロードメニューを開く
  * @param {string} 対象ペイン要素のID
  */
@@ -978,6 +990,7 @@ function loadSettings() {
  */
 function createWebView(id, { url, zoom, customCSS, forOverlay, forSmallPane }) {
   const webview = new WebView({ url, zoom, customCSS });
+  webview.addShortcutKey("meta+l", webview => openUrlChangeDialog(webview));
   if (forOverlay) {
     webview.addShortcutKey("Escape", _ => removeOverlay());
     webview.addShortcutKey("meta+w", _ => removeOverlay());


### PR DESCRIPTION
## WHAT
webViewにキーボードショートカット Cmd + L の追加

ダイアログが開き、対象ペインのタイトルとURLが入っている
URLはコピペ可能で、URLをペーストしてOKを押すと既存ペインで遷移できる

![画面収録 2020-05-09 20 09 21](https://user-images.githubusercontent.com/18308639/81472328-5593ef80-9232-11ea-98ee-9d9a16d7d236.gif)


## WHY
現在開いているペインのURLURLをコピーしたいし、
コピペで特定のページをそのペインで開きたい

## HOW
webViewの中からカスタムイベントを投げて、main.js で Listen する
受け取った main.js は ペインのタイトルと現在開いているURLをダイアログにセットした上で
openNewPaneFromUrlDialog(index) 関数をコールする
(引数にindexをとるので、newPaneといいつつindexさえ採番できていれば既存 pane の遷移もできる）
