### PR TITLE
ボードのエクスポートができていなかった不具合を修正

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -366,10 +366,10 @@ function exportUsingBoard() {
     },
   ).then(result => {
     const fileName = result.filePath;
-      if (fileName) {
-        const data = JSON.stringify(usingBoard, null, 2);
-        writeFile(fileName, data);
-      }
+    if (fileName) {
+      const data = JSON.stringify(usingBoard, null, 2);
+      writeFile(fileName, data);
+    }
   })
 }
 
@@ -811,7 +811,7 @@ function loadAdditionalPage({ name, url, zoom = 1.0, customCSS = [] }) {
  * @param {string} params.zoom
  * @param {[string]} params.customCSS
  */
-function recreateSelectedPane(index, {name, url, zoom, customCSS }) {
+function recreateSelectedPane(index, { name, url, zoom, customCSS }) {
   const div = document.getElementById(`${index}`);
   const webViewElm = div.querySelector("webview");
   convertToWebViewInstance(webViewElm).dispose();

--- a/src/main.js
+++ b/src/main.js
@@ -352,9 +352,7 @@ function exportUsingBoard() {
   // jsonにしたものをファイルに吐き出す
   // allWidthとかとってこれる？
   delete usingBoard.name;
-  const win = remote.getCurrentWindow();
   dialog.showSaveDialog(
-    win,
     {
       properties: ["openFile"],
       filters: [
@@ -364,13 +362,13 @@ function exportUsingBoard() {
         }
       ]
     },
-    fileName => {
+  ).then(result => {
+    const fileName = result.filePath;
       if (fileName) {
         const data = JSON.stringify(usingBoard, null, 2);
         writeFile(fileName, data);
       }
-    }
-  );
+  })
 }
 
 /**

--- a/src/main.js
+++ b/src/main.js
@@ -352,7 +352,9 @@ function exportUsingBoard() {
   // jsonにしたものをファイルに吐き出す
   // allWidthとかとってこれる？
   delete usingBoard.name;
+  const win = remote.getCurrentWindow();
   dialog.showSaveDialog(
+    win,
     {
       properties: ["openFile"],
       filters: [


### PR DESCRIPTION
おそらく #56 で Electron のバージョンを上げたことで、
`showSaveDialog()` の挙動が変わり、エクスポートができなくなった問題に対応します。

参考: https://stackoverflow.com/questions/39078170/electron-dialog-saving-file-not-working

Electron 公式のドキュメントやリリースノートでの言及がなかったのがキモチワルイですが。

正常にエクスポートされることを確認済みです。