### PR TITLE
feat: customUserAgent機能（ペイン別）

### DIFF
--- a/src/components/contentForm.js
+++ b/src/components/contentForm.js
@@ -17,7 +17,7 @@ class ContentForm {
    * Contentの内容に応じたフォームUIを生成する
    */
   createElement() {
-    const { name, url, zoom, customCSS } = this.content.toObject();
+    const { name, url, zoom, customCSS, customUA } = this.content.toObject();
     const $element = $(`
       <div class="item-box">
         <p>
@@ -31,6 +31,10 @@ class ContentForm {
         <p>
           Zoom
           <input value="${zoom}" type="textbox" class="zoom content-textbox" />
+        </p>
+        <p>
+          Custom UserAgent
+          <input value="${customUA}" type="textbox" class="customUA content-textbox" />
         </p>
         <p>
           Custom CSS
@@ -83,6 +87,7 @@ class ContentForm {
     this.content.name = this.$element.find("input.name").val();
     this.content.url = this.$element.find("input.url").val();
     this.content.zoom = this.$element.find("input.zoom").val();
+    this.content.customUA = this.$element.find("input.customUA").val();
     this.content.customCSS = this.$element.find("textarea.custom-css").val().split("\n");
   }
 
@@ -91,8 +96,8 @@ class ContentForm {
    * @params {object} options マージするオブジェクト
    */
   toObject(options = {}) {
-    const { name, url, zoom, customCSS } = this.content.toObject();
-    return { name, url, zoom, customCSS, ...options };
+    const { name, url, zoom, customCSS ,customUA} = this.content.toObject();
+    return { name, url, zoom, customCSS, customUA, ...options };
   }
 
   /**

--- a/src/components/contentForm.js
+++ b/src/components/contentForm.js
@@ -59,6 +59,7 @@ class ContentForm {
 
     $element.children("button").click(() => this.onClickDeleteButton(this));
     $element.find("input,textarea").on("blur", () => this.syncToContent());
+    $element.find("select").on("change", () => this.syncToContent())
     return $element;
   }
 

--- a/src/components/contentForm.js
+++ b/src/components/contentForm.js
@@ -17,6 +17,12 @@ class ContentForm {
    * Contentの内容に応じたフォームUIを生成する
    */
   createElement() {
+    const ua = {
+      default: "",
+      iPhone13: "Mozilla/5.0 (iPhone; CPU iPhone OS 13_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1",
+      Pixel4: "Mozilla/5.0 (Linux; Android 10; Pixel 4 XL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Mobile Safari/537.36"
+    }
+
     const { name, url, zoom, customCSS, customUA } = this.content.toObject();
     const $element = $(`
       <div class="item-box">
@@ -34,7 +40,13 @@ class ContentForm {
         </p>
         <p>
           Custom UserAgent
-          <input value="${customUA}" type="textbox" class="customUA content-textbox" />
+          <select class="customUA content-selectbox">
+            <option ${customUA === "" ? "selected" : ""}>default</option>
+            <option value="${ua.iPhone13}" ${customUA === ua.iPhone13 ? "selected": ""}
+            >iPhone iOS13</option>
+            <option value="${ua.Pixel4}" ${customUA === ua.Pixel4 ? "selected" : ""}
+            >Pixel4 Android10</option>
+          </select>
         </p>
         <p>
           Custom CSS
@@ -87,7 +99,7 @@ class ContentForm {
     this.content.name = this.$element.find("input.name").val();
     this.content.url = this.$element.find("input.url").val();
     this.content.zoom = this.$element.find("input.zoom").val();
-    this.content.customUA = this.$element.find("input.customUA").val();
+    this.content.customUA = this.$element.find("select.customUA").val();
     this.content.customCSS = this.$element.find("textarea.custom-css").val().split("\n");
   }
 

--- a/src/components/webview.js
+++ b/src/components/webview.js
@@ -13,8 +13,10 @@ class WebView {
    * @param {string}   params.url
    * @param {number}   params.zoom
    * @param {[string]} params.customCSS
+   * @param {string} params.customUA
    */
-  constructor({ url, zoom, customCSS }) {
+  constructor({ url, zoom, customCSS, customUA }) {
+    this.customUA = customUA || ""
     this.url = url || "";
     this.zoom = zoom || 1.0;
     this.customCSS = customCSS || [];
@@ -35,6 +37,7 @@ class WebView {
   initialize() {
     if (isValidURL(this.url)) this.element.src = this.url;
     this.element.autosize = "on";
+    this.element.useragent = this.customUA;
     this.element.addEventListener("dom-ready", () => {
       this.apply();
       this.initializeContextMenu();

--- a/src/main.js
+++ b/src/main.js
@@ -971,7 +971,7 @@ function loadSettings() {
  * @param {boolean}  params.forOverlay   オーバレイ用途であるか
  * @param {boolean}  params.forSmallPane smallペイン用途であるか
  */
-function createWebView(id, { url, zoom, customCSS, forOverlay, forSmallPane, customUA }) {
+function createWebView(id, { url, zoom, customCSS, customUA, forOverlay, forSmallPane }) {
   const webview = new WebView({ url, zoom, customCSS, customUA });
   if (forOverlay) {
     webview.addShortcutKey("Escape", _ => removeOverlay());

--- a/src/main.js
+++ b/src/main.js
@@ -827,7 +827,7 @@ function recreateSelectedPane(index, {name, url, zoom, customCSS, customUA }) {
   storeZoom(index, zoom);
   storeCustomUA(index, customUA)
 
-  const webview = createWebView(div.id, { url, zoom, customCSS });
+  const webview = createWebView(div.id, { url, zoom, customCSS, customUA });
   div.appendChild(webview.element);
   addSearchbox(webview)
 }

--- a/src/main.js
+++ b/src/main.js
@@ -211,6 +211,7 @@ function initialize() {
   contents.forEach(function (content) {
     if (content["size"] === undefined) content["size"] = "small";
     if (content["zoom"] === undefined) content["zoom"] = 1.0;
+    if (content["customUA"]  === undefined) content["customUA"] = ""
     createPane(content, true);
   });
   // 描画されたWebviewを操作するためのUIを追加する
@@ -622,6 +623,9 @@ function swapSmallPane(fromIndex, toIndex) {
   storeZoom(toIndex, settings.contents[fromIndex]["zoom"]);
   storeCustomCSS(fromIndex, settings.contents[toIndex]["customCSS"]);
   storeCustomCSS(toIndex, settings.contents[fromIndex]["customCSS"]);
+  storeCustomUA(fromIndex, settings.contents[toIndex]["customUA"]);
+  storeCustomUA(toIndex, settings.contents[fromIndex]["customUA"]);
+
 
   // ペインのIDと表示位置を交換
   [fromPane.id, fromPane.style.order, toPane.id, toPane.style.order] = [
@@ -782,15 +786,16 @@ function getPaneNum() {
  * @param {string} params.zoom
  * @param {[string]} params.customCSS
  */
-function loadAdditionalPage({ name, url, zoom = 1.0, customCSS = [] }) {
+function loadAdditionalPage({ name, url, zoom = 1.0, customCSS = [], customUA = ""}) {
   resetWindowSize();
   const size = "small";
-  createPane({ size, url, zoom, customCSS });
+  createPane({ size, url, zoom, customCSS, customUA });
   storeName(getPaneNum() - 1, name);
   storeSize(getPaneNum() - 1, size);
   storeUrl(getPaneNum() - 1, url);
   storeZoom(getPaneNum() - 1, zoom);
   storeCustomCSS(getPaneNum() - 1, customCSS);
+  storeCustomUA(getPaneNum() - 1, customUA);
 
   const webviewElm = getWebviews()[getPaneNum() - 1];
   const webView = convertToWebViewInstance(webviewElm);
@@ -811,7 +816,7 @@ function loadAdditionalPage({ name, url, zoom = 1.0, customCSS = [] }) {
  * @param {string} params.zoom
  * @param {[string]} params.customCSS
  */
-function recreateSelectedPane(index, {name, url, zoom, customCSS }) {
+function recreateSelectedPane(index, {name, url, zoom, customCSS, customUA }) {
   const div = document.getElementById(`${index}`);
   const webViewElm = div.querySelector("webview");
   convertToWebViewInstance(webViewElm).dispose();
@@ -820,6 +825,7 @@ function recreateSelectedPane(index, {name, url, zoom, customCSS }) {
   storeUrl(index, url);
   storeCustomCSS(index, customCSS);
   storeZoom(index, zoom);
+  storeCustomUA(index, customUA)
 
   const webview = createWebView(div.id, { url, zoom, customCSS });
   div.appendChild(webview.element);
@@ -865,10 +871,19 @@ function storeZoom(index, zoom) {
 /**
  * 現在表示しているペインのカスタムCSSを保存する
  * @param {string} index 対象ペインのID
- * @param {string} size
+ * @param {[string]} customCSS
  */
 function storeCustomCSS(index, customCSS) {
   store.set(`boards.${currentBoardIndex}.contents.${index}.customCSS`, customCSS || []);
+}
+
+/**
+ * 現在表示しているペインのカスタムUAを保存する
+ * @param {string} index 対象ペインのID
+ * @param {string} customUA 
+ */
+function storeCustomUA(index, customUA){
+  store.set(`boards.${currentBoardIndex}.contents.${index}.customUA`, customUA || "");
 }
 
 /**
@@ -879,14 +894,14 @@ function storeCustomCSS(index, customCSS) {
  * @param {[string]} params.customCSS
  * @param {boolean}  init  初期描画による作成であるか
  */
-function createPane({ size, url, zoom, customCSS }, init = false) {
+function createPane({ size, url, zoom, customCSS, customUA }, init = false) {
   let divContainer = createContainerDiv(size);
   let divButtons = createButtonDiv();
 
   document.getElementById("main-content").appendChild(divContainer);
   divContainer.appendChild(divButtons);
   const forSmallPane = size === "small";
-  const webview = createWebView(divContainer.id, { url, zoom, customCSS, forSmallPane });
+  const webview = createWebView(divContainer.id, { url, zoom, customCSS, forSmallPane, customUA});
   divContainer.appendChild(webview.element);
 
   createDraggableBar(size);
@@ -956,8 +971,8 @@ function loadSettings() {
  * @param {boolean}  params.forOverlay   オーバレイ用途であるか
  * @param {boolean}  params.forSmallPane smallペイン用途であるか
  */
-function createWebView(id, { url, zoom, customCSS, forOverlay, forSmallPane }) {
-  const webview = new WebView({ url, zoom, customCSS });
+function createWebView(id, { url, zoom, customCSS, forOverlay, forSmallPane, customUA }) {
+  const webview = new WebView({ url, zoom, customCSS, customUA });
   if (forOverlay) {
     webview.addShortcutKey("Escape", _ => removeOverlay());
     webview.addShortcutKey("meta+w", _ => removeOverlay());

--- a/src/models/content.js
+++ b/src/models/content.js
@@ -13,7 +13,7 @@ class Content {
    * @param {string}   params.height
    * @param {[string]} params.customCSS
    */
-  constructor({ name, url, zoom, size, allWidth, width, height, customCSS } = {}) {
+  constructor({ name, url, zoom, size, allWidth, width, height, customCSS, customUA } = {}) {
     this.name = name || "";
     this.url = url || "";
     this.zoom = zoom || 1.0;
@@ -22,6 +22,7 @@ class Content {
     this.width = width || undefined;
     this.height = height || undefined;
     this.customCSS = customCSS || [];
+    this.customUA = customUA || "";
   }
 
   /**
@@ -75,7 +76,8 @@ class Content {
       allWidth: this.allWidth,
       width: this.width,
       height: this.height,
-      customCSS: this.customCSS
+      customCSS: this.customCSS,
+      customUA: this.customUA
     };
   }
 

--- a/src/preference.css
+++ b/src/preference.css
@@ -193,6 +193,11 @@ a.article:hover {
   width: 100%;
 }
 
+.content-selectbox {
+  width: 100%;
+  height: 2em;
+}
+
 .textarea-ccss {
   width: 100%;
   height: 120px;


### PR DESCRIPTION
## WHAT
UserAgentの偽装機能をつける

添付の画像の左側がUA偽装でのGoogle、右側がデフォルトUAでのGoogle
<img width="1330" alt="スクリーンショット 2020-05-09 23 36 25" src="https://user-images.githubusercontent.com/18308639/81476705-41f68200-924e-11ea-84ce-808c8799dca2.png">

![スクリーンショット 2020-05-09 23 56 04](https://user-images.githubusercontent.com/18308639/81477079-add9ea00-9250-11ea-90fa-688817cbe030.png)


## WHY
#62 
スモールペインのサイズ感がスマホに似てるので、UserAgentをスマホのものに偽装したらいい感じになりそう

## HOW
設定画面にペインごとのcustomUserAgentカラムを追加
`<webview>` が useragent attributeをとるので付与してやる
https://www.electronjs.org/docs/api/webview-tag#useragent