### PR TITLE
初回起動時に Setting 生成に失敗する問題を修正

### DIFF
--- a/src/setting.js
+++ b/src/setting.js
@@ -21,9 +21,15 @@ class Setting {
    */
   loadAllSettings() {
     this.store = electronStore.store;
-    this.version = this.store["version"];
-    this.usingBoardList = this.loadUsingBoardList();
-    this.definedBoardList = this.loadDefinedBoardList();
+    if (Object.keys(this.store).length === 0) {
+      this.version = this.appVersion;
+      this.usingBoardList = [];
+      this.definedBoardList = [];
+    } else {
+      this.version = this.store["version"];
+      this.usingBoardList = this.loadUsingBoardList();
+      this.definedBoardList = this.loadDefinedBoardList();
+    }
   }
 
   /**


### PR DESCRIPTION
## 前提
![image](https://user-images.githubusercontent.com/8579173/81484594-97985200-9281-11ea-8cff-421623a0dfd3.png)

初回起動時、ウェルカムボードに Slack のワークスペースを入力したあとでフリーズする。

## 概要
存在しない `boards` や `options` キーを参照して落ちていたので、
store の中身が空のときは `usingBoardList` や `definedBoardList` を空配列で初期化する。

起動確認はできましたが、別のとこでやったほうがキレイなどあったらご指摘ください〜