### PR TITLE
preference画面にて、customUAをdefaultに戻した際の挙動対応

### DIFF
--- a/src/components/contentForm.js
+++ b/src/components/contentForm.js
@@ -19,9 +19,11 @@ class ContentForm {
   createElement() {
     const ua = {
       default: "",
-      iPhone13: "Mozilla/5.0 (iPhone; CPU iPhone OS 13_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1",
-      Pixel4: "Mozilla/5.0 (Linux; Android 10; Pixel 4 XL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Mobile Safari/537.36"
-    }
+      iPhone13:
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 13_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1",
+      Pixel4:
+        "Mozilla/5.0 (Linux; Android 10; Pixel 4 XL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Mobile Safari/537.36"
+    };
 
     const { name, url, zoom, customCSS, customUA } = this.content.toObject();
     const $element = $(`
@@ -41,11 +43,15 @@ class ContentForm {
         <p>
           Custom UserAgent
           <select class="customUA content-selectbox">
-            <option ${customUA === "" ? "selected" : ""}>default</option>
-            <option value="${ua.iPhone13}" ${customUA === ua.iPhone13 ? "selected": ""}
-            >iPhone iOS13</option>
-            <option value="${ua.Pixel4}" ${customUA === ua.Pixel4 ? "selected" : ""}
-            >Pixel4 Android10</option>
+            <option value="${ua.default}" ${customUA === "" ? "selected" : ""}>
+              default
+            </option>
+            <option value="${ua.iPhone13}" ${customUA === ua.iPhone13 ? "selected" : ""}>
+              iPhone iOS13
+            </option>
+            <option value="${ua.Pixel4}" ${customUA === ua.Pixel4 ? "selected" : ""}>
+              Pixel4 Android10
+            </option>
           </select>
         </p>
         <p>
@@ -59,7 +65,7 @@ class ContentForm {
 
     $element.children("button").click(() => this.onClickDeleteButton(this));
     $element.find("input,textarea").on("blur", () => this.syncToContent());
-    $element.find("select").on("change", () => this.syncToContent())
+    $element.find("select").on("change", () => this.syncToContent());
     return $element;
   }
 
@@ -109,7 +115,7 @@ class ContentForm {
    * @params {object} options マージするオブジェクト
    */
   toObject(options = {}) {
-    const { name, url, zoom, customCSS ,customUA} = this.content.toObject();
+    const { name, url, zoom, customCSS, customUA } = this.content.toObject();
     return { name, url, zoom, customCSS, customUA, ...options };
   }
 

--- a/src/models/content.js
+++ b/src/models/content.js
@@ -19,9 +19,9 @@ class Content {
     this.url = params.url || "";
     this.zoom = params.zoom || 1.0;
     this.size = params.size || "small";
-    this.allWidth = params.llWidth || undefined;
-    this.width = params.idth || undefined;
-    this.height = params.eight || undefined;
+    this.allWidth = params.allWidth || undefined;
+    this.width = params.width || undefined;
+    this.height = params.height || undefined;
     this.customCSS = params.customCSS || [];
     this.customUA = params.customUA || "";
   }

--- a/src/models/content.js
+++ b/src/models/content.js
@@ -12,17 +12,18 @@ class Content {
    * @param {string}   params.width
    * @param {string}   params.height
    * @param {[string]} params.customCSS
+   * @param {string}   params.customUA
    */
-  constructor({ name, url, zoom, size, allWidth, width, height, customCSS, customUA } = {}) {
-    this.name = name || "";
-    this.url = url || "";
-    this.zoom = zoom || 1.0;
-    this.size = size || "small";
-    this.allWidth = allWidth || undefined;
-    this.width = width || undefined;
-    this.height = height || undefined;
-    this.customCSS = customCSS || [];
-    this.customUA = customUA || "";
+  constructor(params = {}) {
+    this.name = params.name || "";
+    this.url = params.url || "";
+    this.zoom = params.zoom || 1.0;
+    this.size = params.size || "small";
+    this.allWidth = params.llWidth || undefined;
+    this.width = params.idth || undefined;
+    this.height = params.eight || undefined;
+    this.customCSS = params.customCSS || [];
+    this.customUA = params.customUA || "";
   }
 
   /**


### PR DESCRIPTION
`preference` 画面にて、`customUA` をiPhoneなどに変更後、再度`default` に戻した際に、空文字が設定ファイルに記述されて欲しいところ "default" という文字列が設定され、不正なUAと認識されてしまう問題を風清