### PR TITLE
ボードのインポートができないバグを修正

### DIFF
--- a/src/preference.js
+++ b/src/preference.js
@@ -115,9 +115,8 @@ function createContentForm(board, content) {
  */
 function openFileAndSave() {
   const win = remote.getCurrentWindow();
-  remote.dialog.showOpenDialog(
-    win,
-    {
+  remote.dialog
+    .showOpenDialog(win, {
       properties: ["openFile"],
       filters: [
         {
@@ -125,13 +124,12 @@ function openFileAndSave() {
           extensions: ["json"]
         }
       ]
-    },
-    filePath => {
-      if (filePath) {
-        showModalDialogElement(filePath[0]);
+    })
+    .then(result => {
+      if (result.filePaths) {
+        showModalDialogElement(result.filePaths[0]);
       }
-    }
-  );
+    });
 }
 
 /**


### PR DESCRIPTION
おそらく https://github.com/konoyono/okadash/pull/61 と同じ事象。

ドキュメント見る限りは、いつのまにかコールバック関数取るんじゃなくてPromiseを戻すように破壊的変更入ったっぽいですね。

https://www.electronjs.org/docs/api/dialog#dialogshowopendialogbrowserwindow-options